### PR TITLE
feat(header): add links and styles to header

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -3,6 +3,32 @@ module.exports = {
     title: `Idiosyncrasy`,
     description: `A fanfic marketing site inspired by Quirk.`,
     author: `twitch chat`,
+    navLinks: [
+      {
+        title: "Features",
+        route: "/features",
+      },
+      {
+        title: "Support",
+        route: "/support",
+      },
+      {
+        title: "Pricing",
+        route: "/pricing",
+      },
+      {
+        title: "News",
+        route: "/news",
+      },
+      {
+        title: "Login",
+        cta: true,
+      },
+      {
+        title: "Sign Up",
+        cta: true,
+      },
+    ],
   },
   pathPrefix: "/idiosyncrasy",
   plugins: [

--- a/src/common/buttons.js
+++ b/src/common/buttons.js
@@ -1,0 +1,8 @@
+import styled from "styled-components"
+
+export const CTAButton = styled.button`
+  border: none;
+  height: 80px;
+  width: 139px;
+  background-color: transparent;
+`

--- a/src/common/wrappers.js
+++ b/src/common/wrappers.js
@@ -1,0 +1,7 @@
+import styled from "styled-components"
+
+export const FlexWrapper = styled.div`
+  display: flex;
+  place-items: center;
+  justify-content: space-between;
+`

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -3,32 +3,68 @@ import PropTypes from "prop-types"
 import React from "react"
 import styled from "styled-components"
 
+import { FlexWrapper } from "../common/wrappers"
 import { InnerWrapper } from "./layout"
+import { CTAButton } from "../common/buttons"
 
 import colors from "../common/colors"
 
 const StyledHeader = styled.header`
   background: ${colors.backgrounds.header};
+  h1 {
+    margin: auto 0;
+  }
 `
 
-const Header = ({ siteTitle }) => (
+const NavButtonWrapper = styled.div`
+  & ${CTAButton}:nth-child(2) {
+    background-color: ${colors.actions.main};
+    color: #fff;
+  }
+`
+
+const HeaderLink = styled(Link)`
+  text-decoration: none;
+  color: #000;
+  margin: 0 50px;
+`
+
+const Header = ({ siteTitle, navLinks }) => (
   <StyledHeader>
     <InnerWrapper>
-      <div>
+      <FlexWrapper>
         <h1>
-          <Link>{siteTitle}</Link>
+          <HeaderLink to="/">{siteTitle}</HeaderLink>
         </h1>
-      </div>
+
+        <div>
+          {navLinks.map(link => {
+            if (!link.cta) {
+              return <HeaderLink to={link.route}>{link.title}</HeaderLink>
+            }
+          })}
+        </div>
+
+        <NavButtonWrapper>
+          {navLinks.map(link => {
+            if (link.cta) {
+              return <CTAButton>{link.title}</CTAButton>
+            }
+          })}
+        </NavButtonWrapper>
+      </FlexWrapper>
     </InnerWrapper>
   </StyledHeader>
 )
 
 Header.propTypes = {
   siteTitle: PropTypes.string,
+  navLinks: PropTypes.array,
 }
 
 Header.defaultProps = {
   siteTitle: ``,
+  navLinks: [],
 }
 
 export default Header

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -22,6 +22,10 @@ const _Layout = ({ children }) => {
       site {
         siteMetadata {
           title
+          navLinks {
+            title
+            cta
+          }
         }
       }
     }
@@ -29,7 +33,10 @@ const _Layout = ({ children }) => {
 
   return (
     <>
-      <Header siteTitle={data.site.siteMetadata.title} />
+      <Header
+        siteTitle={data.site.siteMetadata.title}
+        navLinks={data.site.siteMetadata.navLinks}
+      />
       <div
         style={{
           minHeight: "500px",


### PR DESCRIPTION
Add navLinks to header from siteMetadata and style header according to figma spec

- Add navLinks to siteMetadata to be reusable in the footer
- Add buttons module for button styled-components
- Add wrapper module for wrapper styled-components

re #4